### PR TITLE
ディレクターに稼働集計と日報未提出一覧が見られる権限を付与

### DIFF
--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -8,7 +8,7 @@ class ReportPolicy < ApplicationPolicy
   end
 
   def summary?
-    user.administrator?
+    user.administrator? || user.director?
   end
 
   def unsubmitted?


### PR DESCRIPTION
## このPRで解決される問題

- ディレクター権限を持つユーザーが管理画面でできることが確定
    - プロジェクト管理
    - 稼働集計
    - 日報未提出一覧