### PR TITLE
エラーメッセージのビジュアルを控えめにした。

### DIFF
--- a/app/assets/stylesheets/reports.scss
+++ b/app/assets/stylesheets/reports.scss
@@ -40,6 +40,10 @@ ul.date-pager {
         text-align: right;
         width: 3.5em;
       }
+      span.alert {
+        font-size: 12px;
+        padding: 0.2em 0.5em;
+      }
     }
   }
 }


### PR DESCRIPTION
# このPRで解決される問題

日報入力フォームで不正な入力があった際に表示されるエラーメッセージのコンポーネントが大きすぎて、他の要素と重なり合ってしまうため、paddingとfont-sizeの調整を行った。