### PR TITLE
プロジェクト削除機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,16 @@ gem 'mysql2', '>= 0.3.18', '< 0.5'
 gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
+# Use honoka-rails (Bootstrap Theme for Japanese)
 gem 'honoka-rails'
+# Use Slim for templating engine
 gem 'slim-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails'
+# Use Data-Confirm Modal
+gem 'data-confirm-modal'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    data-confirm-modal (1.3.0)
+      railties (>= 3.0)
     devise (4.3.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -271,6 +273,7 @@ DEPENDENCIES
   byebug
   capistrano-rails
   coffee-rails
+  data-confirm-modal
   devise
   devise-encryptable
   factory_girl_rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require bootstrap-sprockets
+//= require data-confirm-modal
 //= require moment
 //= require moment/ja.js
 //= require bootstrap-datetimepicker

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -72,6 +72,12 @@ class ProjectsController < ApplicationController
     end
   end
 
+  def destroy
+    authorize @project
+    @project.destroy!
+    redirect_to projects_path, notice: "プロジェクト「#{@project.name}」を削除しました。"
+  end
+
   private
 
   def get_resource

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 class Project < ApplicationRecord
   has_many :operations
-  has_many :user_projects
+  has_many :user_projects, dependent: :destroy
   has_many :users, through: :user_projects
 
   validates :code,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_many :user_roles, through: :user_role_associations
   has_many :reports
   has_many :operations, through: :reports
-  has_many :user_projects
+  has_many :user_projects, dependent: :destroy
   has_many :projects, through: :user_projects
 
   accepts_nested_attributes_for :user_roles

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -21,6 +21,13 @@ dl.row
     .nav.navbar-nav
       = link_to 'このプロジェクトを編集', edit_project_path(@project.id), class: 'btn btn-primary navbar-btn'
 
+      = form_with model: @project,
+                  method: :delete,
+                  class: 'navbar-form navbar-right',
+                  data: { title: '削除の確認',
+                          confirm: 'このプロジェクトを削除します。よろしいですか？'} do |f|
+        = f.submit 'このプロジェクトを削除', class: 'btn btn-danger'
+
 h2 このプロジェクトの日報を投稿したメンバー
 
 - if @project.members.present?


### PR DESCRIPTION
# このPRで解決される問題

- プロジェクトを間違って登録しても削除ができなかったため、機能を実装した。
- `Project`と`UserProject`のリレーションに`dependent: :destroy`オプションを追加した。