### PR TITLE
datetimepickerの選択月以外の日の文字色を薄くした。

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -56,3 +56,10 @@ form {
 .form-group .date input.date-input {
   width: 7em;
 }
+
+// Bootstrap Datetimepicker
+.bootstrap-datetimepicker-widget table {
+  td.new, td.old {
+    color: #bbbbbb;
+  }
+}


### PR DESCRIPTION
# このPRで解決される問題

- [Bootstrap 3 Datepicker](https://eonasdan.github.io/bootstrap-datetimepicker/)を日付選択UIに利用しているが、選択している月の前後の月の日の文字色が濃く、選択月との違いがわかりづらいという指摘があったため、色を薄くした。