### PR TITLE
日報登録のUI改善

### DIFF
--- a/app/assets/javascripts/components/calendar.js.jsx
+++ b/app/assets/javascripts/components/calendar.js.jsx
@@ -388,14 +388,14 @@ var ReportForm = React.createClass({
         return;
       }
       var intval = parseInt(val);
-      if (intval < 0 || 100 < intval) {
-        errors[index] = '稼働率は0〜100の間で設定してください。';
+      if (intval <= 0 || 100 < intval) {
+        errors[index] = '稼働率は1〜100の間で設定してください。';
         return;
       }
       total += intval;
     }, this);
     if (total != 100) {
-      this.setState({ reportError: '稼働率の合計が100になっていません。' });
+      this.setState({ reportError: '稼働率の合計が100になっていません。現在'+ total +'%です。' });
     }
     this.setState({ operationErrors: errors });
     return total == 100 && errors.join('') == '';

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -36,7 +36,7 @@ class ReportsController < ApplicationController
 
       format.any do
         @date = get_date || Time.zone.now.to_date
-        @projects = current_user.projects.available
+        @projects = current_user.projects.available.order_by_reading
         # render view
       end
     end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,6 +17,8 @@ class Project < ApplicationRecord
 
   scope :available, -> { where(hidden: false) }
 
+  scope :order_by_reading, -> { order(name_reading: :asc) }
+
   class << self
     # 該当のユーザーが関与しているかの情報を含むリストを取得
     # @param [Integer] user_id


### PR DESCRIPTION
# このPRで解決される問題

- ユーザーが日報登録をする際のプロジェクトのプルダウンメニューのプロジェクトの並びを、プロジェクトのふりがなの昇順に設定した。探しやすくすることが目的。
- 日報登録時に稼働率合計が100%でないエラーが出た時のメッセージに、現在の稼働率合計を表示するようにした。