### PR TITLE
form_for および form_tag を form_with に置き換え

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,7 +58,7 @@ module ApplicationHelper
   end
 
   def signout_form
-    form_tag destroy_user_session_path, method: 'delete', class: 'navbar-form navbar-right' do
+    form_with url: destroy_user_session_path, method: 'delete', class: 'navbar-form navbar-right' do
       submit_tag 'ログアウト', class: 'btn btn-default'
     end
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,13 +1,13 @@
 module UsersHelper
   def destroy_or_revive_button(user)
     if user.available?
-      form_for user, method: :delete do |f|
+      form_with model: user, method: :delete do |f|
         f.submit('このユーザーを集計対象から外す',
                  class: 'btn btn-danger navbar-btn',
                  data: { confirm: "このユーザーを集計対象から外します。\n全てのプロジェクトからこのユーザーの関連付けが削除されます。\nよろしいですか？" })
       end
     else
-      form_for user, url: revive_user_path(user), method: :patch do |f|
+      form_with model: user, url: revive_user_path(user), method: :patch do |f|
         f.submit('このユーザーを集計対象に加える',
                  class: 'btn btn-success navbar-btn',
                  data: { confirm: 'このユーザーを集計対象に加えます。よろしいですか？' })

--- a/app/views/admin/csvs/index.html.slim
+++ b/app/views/admin/csvs/index.html.slim
@@ -6,7 +6,7 @@ h2 提出済みの日報一覧
 
 = render_flash_message
 
-= form_tag reports_path(format: :csv), method: :get, id: 'reports', class: 'form-inline' do
+= form_with url: reports_path(format: :csv), method: :get, id: 'reports', class: 'form-inline' do
   .form-group
     .input-group.date
       input.form-control.date-input type="text" name="reports[start]" placeholder="集計開始日"
@@ -22,12 +22,12 @@ h2 提出済みの日報一覧
 
 h2 プロジェクト一覧
 
-= form_tag projects_path(format: :csv), method: :get do
+= form_with url: projects_path(format: :csv), method: :get do
   = submit_tag 'ダウンロード', class: 'btn btn-primary'
 
 h2 ユーザー一覧
 
-= form_tag users_path(format: :csv), method: :get do
+= form_with url: users_path(format: :csv), method: :get do
   = submit_tag 'ダウンロード', class: 'btn btn-primary'
 
 javascript:

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for project, html: { class: 'form-horizontal' } do |f|
+= form_with model: project, html: { class: 'form-horizontal' } do |f|
   .form-group
     label.col-sm-2.control-label= t('project.code')
     .col-sm-10

--- a/app/views/reports/summaries/show.html.slim
+++ b/app/views/reports/summaries/show.html.slim
@@ -6,7 +6,7 @@ h1 稼働集計
 
 .d-flex.flex-row.align-items-baseline
   .p-2
-    = form_tag summary_path, method: :get, class: 'form-inline', id: 'summaryRender' do
+    = form_with url: summary_path, method: :get, class: 'form-inline', id: 'summaryRender' do
       .form-group
         .input-group.date
           input.form-control.date-input type="text" name="reports[start]" placeholder="集計開始日" value="#{@start_date.strftime('%Y-%m-%d')}"
@@ -22,7 +22,7 @@ h1 稼働集計
   .p-2
     | または
   .p-2
-    = form_tag summary_path(format: :csv), method: :get, id: 'summaryDownload' do
+    = form_with url: summary_path(format: :csv), method: :get, id: 'summaryDownload' do
       = submit_tag 'CSVダウンロード', class: 'btn btn-primary'
 
 - if params[:reports].present?

--- a/app/views/reports/unsubmitteds/show.html.slim
+++ b/app/views/reports/unsubmitteds/show.html.slim
@@ -4,7 +4,7 @@ h1 日報未提出一覧
 
 = render_flash_message
 
-= form_tag unsubmitted_path, method: :get, class: 'form-inline' do
+= form_with url: unsubmitted_path, method: :get, class: 'form-inline' do
   .form-group
     .input-group.date
       input.form-control.date-input type="text" name="reports[start]" placeholder="集計開始日" value="#{@start_date.strftime('%Y-%m-%d')}"

--- a/app/views/settings/passwords/show.html.slim
+++ b/app/views/settings/passwords/show.html.slim
@@ -2,7 +2,7 @@ h1 パスワード変更
 
 = render_flash_message
 
-= form_tag settings_password_path, method: :put, class: 'form-horizontal' do
+= form_with url: settings_password_path, method: :put, class: 'form-horizontal' do
   .form-group
     label.col-sm-3.control-label= t('user.new_password')
     .col-sm-9

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,4 +1,4 @@
-= form_for user, html: { class: 'form-horizontal' } do |f|
+= form_with model: user, html: { class: 'form-horizontal' } do |f|
   .form-group
     label.col-sm-2.control-label= t('user.name')
     .col-sm-10

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= content_tag :div, flash[:alert], class: 'alert alert-danger' if flash[:alert] %>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
+<%= form_with(model: resource, as: resource_name, url: session_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
   <div class="field form-group">
     <%= f.label :email, class: 'col-sm-2 control-label' %>
     <div class="col-sm-10">


### PR DESCRIPTION
# このPRで解決される問題

- Rails 5.1 で、[`form_for` と `form_tag` が `form_with` に統合された](https://github.com/rails/rails/issues/25197)。
- Rails 6系では、`form_for`, `form_tag` は非推奨になる予定なので、この機に置き換えを行う。