### PR TITLE
Safariでも日報登録できるように修正

### DIFF
--- a/app/assets/javascripts/components/calendar.js.jsx
+++ b/app/assets/javascripts/components/calendar.js.jsx
@@ -381,19 +381,21 @@ var ReportForm = React.createClass({
    * @return {boolean}
    */
   validate: function(data) {
-    var total = 0, errors = [];
-    data.getAll('workloads[]').map(function(val, index) {
-      if (val == '') {
+    var total = 0, errors = [], index = -1, intval;
+    for (var key_value of data) {
+      if (key_value[0] != 'workloads[]') continue;
+      index++;
+      if (key_value[1] == '') {
         errors[index] = '稼働率が設定されていません。';
-        return;
+        continue;
       }
-      var intval = parseInt(val);
+      intval = parseInt(key_value[1]);
       if (intval <= 0 || 100 < intval) {
         errors[index] = '稼働率は1〜100の間で設定してください。';
-        return;
+        continue;
       }
       total += intval;
-    }, this);
+    }
     if (total != 100) {
       this.setState({ reportError: '稼働率の合計が100になっていません。現在'+ total +'%です。' });
     }


### PR DESCRIPTION
# このPRで解決される問題

- SafariはJavaScriptの`FormData`オブジェクトのメソッド`getAll()`が未実装で、日報のvalidate時に例外となり、登録ができなかった。
- `formData.getAll()`の代替として`for(val of formData)`構文を利用し、同等の処理を行うように修正した。

関連Issue: #28 