### PR TITLE
Fix report mailer

### DIFF
--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -5,7 +5,7 @@ class ReportMailer < ApplicationMailer
   def unsubmitted_notification(user, dates)
     @user = user
     @dates = dates
-    @site_url = 'http://daily-report.kibihara-dev.xtone.local/'
+    @site_url = 'http://daily-report.xtone.co.jp/'
     mail(to: user.email, subject: "【日報未提出通知】#{user.name}_#{Time.zone.now.strftime('%Y/%m/%d')}")
   end
 end

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -1,4 +1,7 @@
 class ReportMailer < ApplicationMailer
+  # 日報未提出者にメールを送信する
+  # @param [User] user
+  # @param [Array] date 日付文字列の配列
   def unsubmitted_notification(user, dates)
     @user = user
     @dates = dates

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -119,7 +119,7 @@ namespace :app do
   desc '日報未提出者にメールを送信する'
   task unsubmitted_notification_mail: :environment do
     User.available.each do |user|
-      dates = Report.unsubmitted_dates(user.id)
+      dates = Report.unsubmitted_dates(user.id).map(&:to_s)
       next if dates.blank?
       ReportMailer.unsubmitted_notification(user, dates).deliver_later
     end


### PR DESCRIPTION
## このPRで解決される問題

- 日報未提出者にメールを送信する機能で、ActiveJobがDate型の引数を取ることができないため、引数をStringに変換してから渡すように修正する。