### PR TITLE
Add user.division

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'gretel'
 gem 'momentjs-rails', '>= 2.9.0'
 gem 'bootstrap3-datetimepicker-rails', '~> 4.14.30'
 
+# Use EnumHelp to work fine with I18n
+gem 'enum_help'
+
 # Use Spreadsheet to read xls file
 gem 'spreadsheet'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.7.0)
     execjs (2.7.0)
     factory_girl (4.9.0)
@@ -281,6 +283,7 @@ DEPENDENCIES
   data-confirm-modal
   devise
   devise-encryptable
+  enum_help
   factory_girl_rails
   gretel
   holidays

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :rememberable, :encryptable
 
+  enum division: { undefined: 0, sales_director: 1, engineer: 2, designer: 3, other: 4 }
+
   has_many :user_role_associations, dependent: :destroy
   has_many :user_roles, through: :user_role_associations
   has_many :reports

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -1,3 +1,5 @@
+= render_flash_message
+
 = form_with model: user, html: { class: 'form-horizontal' } do |f|
   .form-group
     label.col-sm-2.control-label= t('user.name')
@@ -34,6 +36,14 @@
         label.checkbox-inline
           = check_box_tag 'user_roles[]', value, user.user_roles.any?{ |u| u.send("#{role}?") }
           = t("user_role.#{role}")
+  .form-group
+    label.col-sm-2.control-label= t('user.division')
+    .col-sm-10
+      - User.divisions_i18n.each do |key, value|
+        - next if key == 'undefined'
+        label.radio-inline
+          = f.radio_button :division, key
+          = value
   .form-group
     .col-sm-offset-2.col-sm-10
       = f.submit user.new_record? ? '登録' : '更新', class: 'btn btn-default'

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -21,6 +21,7 @@ table.table.table-hover
     th= t('user.name')
     th= t('user.email')
     th= t('user.began_on')
+    th= t('user.division')
     th= t('user.available')
     th= t('user.role')
   - @users.each do |user|
@@ -29,5 +30,6 @@ table.table.table-hover
       td= link_to user.name, edit_user_path(user.id)
       td= user.email
       td= user.began_on&.strftime('%Y/%m/%d')
+      td= user.division_i18n
       td= available_label(user)
       td= role_labels(user)

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -10,6 +10,7 @@ ja:
     new_password_confirmation: 新しいパスワード(確認)
     available: 集計中
     role: 権限
+    division: 職種
     began_on: 日報集計開始日
     status:
       available: 集計中
@@ -49,3 +50,12 @@ ja:
 
   activemodel:
     <<: *activerecord
+
+  enums:
+    user:
+      division:
+        undefined: 未設定
+        sales_director: 営業＆ディレクター
+        engineer: エンジニア
+        designer: デザイナー
+        other: その他

--- a/db/migrate/20171113040324_add_column_division_to_users.rb
+++ b/db/migrate/20171113040324_add_column_division_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnDivisionToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :division, :integer, default: 0, null: false, after: :remember_created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161202034233) do
+ActiveRecord::Schema.define(version: 20171113040324) do
 
   create_table "operations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "report_id"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 20161202034233) do
     t.string "email"
     t.string "encrypted_password", default: "", null: false
     t.datetime "remember_created_at"
+    t.integer "division", default: 0, null: false
     t.date "began_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## このPRで解決される問題

- `user.division`を追加する。
- enum属性を持ち、「営業＆ディレクター」「エンジニア」「デザイナー」「その他」のどれかひとつの値を持つ。
- 初期値は「未設定」になっているため、既存ユーザーに対して`division`の設定をする必要がある。
- ついでにユーザーの新規登録ができない問題を修正。

Issue: #45, #50  