### PR TITLE
Add category to project

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -85,6 +85,6 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:name, :code, :name_reading, :hidden)
+    params.require(:project).permit(:name, :code, :name_reading, :category, :hidden)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,6 @@
 class Project < ApplicationRecord
+  enum category: { undefined: 0, client_shot: 1, client_maintenance: 2, internal: 3, general_affairs: 4, other: 5 }
+
   has_many :operations
   has_many :user_projects, dependent: :destroy
   has_many :users, through: :user_projects

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -15,6 +15,14 @@
       = f.text_field :name_reading, class: 'form-control'
       = error_message project, :name_reading
   .form-group
+    label.col-sm-2.control-label= t('project.category')
+    .col-sm-10
+      - Project.categories_i18n.each do |key, value|
+        - next if key == 'undefined'
+        label.radio-inline
+          = f.radio_button :category, key
+          = value
+  .form-group
     .col-sm-offset-2.col-sm-10
       .checkbox
         label

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -11,6 +11,9 @@ dl.row
   dt.col-sm-2= t('project.name')
   dd.col-sm-10= text_with_ruby(@project.name, @project.name_reading)
 
+  dt.col-sm-2= t('project.category')
+  dd.col-sm-10= @project.category_i18n
+
   dt.col-sm-2= t('project.displayed')
   dd.col-sm-10
     = display_status(@project)

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -29,6 +29,7 @@ ja:
     code: PJコード
     name: プロジェクト名
     name_reading: 読みかな
+    category: 種別
     displayed: 表示ステータス
     hidden: 非表示
     created_at: 作成日
@@ -52,6 +53,14 @@ ja:
     <<: *activerecord
 
   enums:
+    project:
+      category:
+        undefined: 未設定
+        client_shot: 通常PJ
+        client_maintenance: 保守PJ
+        internal: 社内PJ
+        general_affairs: 社内業務
+        other: その他
     user:
       division:
         undefined: 未設定

--- a/db/migrate/20171113072354_add_column_category_to_projects.rb
+++ b/db/migrate/20171113072354_add_column_category_to_projects.rb
@@ -1,0 +1,5 @@
+class AddColumnCategoryToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :category, :integer, default: 0, null: false, after: :name_reading
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171113040324) do
+ActiveRecord::Schema.define(version: 20171113072354) do
 
   create_table "operations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "report_id"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 20171113040324) do
     t.integer "code"
     t.string "name"
     t.string "name_reading"
+    t.integer "category", default: 0, null: false
     t.boolean "hidden", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## このPRで解決される問題

- project.category`を追加する。
- enum属性を持ち、「通常PJ」「保守PJ」「社内PJ」「社内業務」「その他」のどれかひとつの値を持つ。
- 初期値は「未設定」になっているため、既存プロジェクトに対して`category`の設定をする必要がある。

Issue: #44