### PR TITLE
Create estimate

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,8 +13,10 @@
 @import "bootstrap-sprockets";
 @import "honoka";
 @import 'bootstrap-datetimepicker';
+@import "bootstrap-overwrite";
 @import "reports";
 @import "projects";
+@import "estimates";
 
 form {
   .alert {
@@ -28,38 +30,4 @@ form {
 
 .field_with_errors {
   @extend .has-error;
-}
-
-// Bootstrap 4 alpha Flexbox
-.flex-row {
-  -webkit-box-orient: horizontal!important;
-  -webkit-box-direction: normal!important;
-  -webkit-flex-direction: row!important;
-  flex-direction: row!important;
-}
-.d-flex {
-  display: -webkit-box!important;
-  display: -webkit-flex!important;
-  display: -ms-flexbox!important;
-  display: flex!important;
-}
-.align-items-baseline {
-  -webkit-box-align: baseline!important;
-  -webkit-align-items: baseline!important;
-  -ms-flex-align: baseline!important;
-  align-items: baseline!important;
-}
-.p-2 {
-  padding: .5rem .5rem!important;
-}
-
-.form-group .date input.date-input {
-  width: 7em;
-}
-
-// Bootstrap Datetimepicker
-.bootstrap-datetimepicker-widget table {
-  td.new, td.old {
-    color: #bbbbbb;
-  }
 }

--- a/app/assets/stylesheets/bootstrap-overwrite.scss
+++ b/app/assets/stylesheets/bootstrap-overwrite.scss
@@ -1,0 +1,40 @@
+// Bootstrap 4 alpha Flexbox
+.flex-row {
+  -webkit-box-orient: horizontal!important;
+  -webkit-box-direction: normal!important;
+  -webkit-flex-direction: row!important;
+  flex-direction: row!important;
+}
+.d-flex {
+  display: -webkit-box!important;
+  display: -webkit-flex!important;
+  display: -ms-flexbox!important;
+  display: flex!important;
+}
+.align-items-baseline {
+  -webkit-box-align: baseline!important;
+  -webkit-align-items: baseline!important;
+  -ms-flex-align: baseline!important;
+  align-items: baseline!important;
+}
+.p-2 {
+  padding: .5rem .5rem!important;
+}
+
+.form-group .date input.date-input {
+  width: 7em;
+}
+
+// Bootstrap Datetimepicker
+.bootstrap-datetimepicker-widget table {
+  td.new, td.old {
+    color: #bbbbbb;
+  }
+}
+
+div .btn {
+  margin-right: 5px;
+  &:last-child {
+    margin-right: 0;
+  }
+}

--- a/app/assets/stylesheets/estimates.scss
+++ b/app/assets/stylesheets/estimates.scss
@@ -1,0 +1,29 @@
+dl.dl-horizontal.estimate {
+  dt {
+    width: 210px;
+  }
+  dd {
+    margin-left: 225px;
+  }
+}
+
+#estimates {
+  .panel.drop-area {
+    .panel-body {
+      padding-top: 50px;
+      padding-bottom: 50px;
+      text-align: center;
+
+      &.dragover {
+        border: #cccccc 4px dashed;
+      }
+    }
+  }
+  table.confirm {
+    table-layout: fixed;
+    th {
+      text-align: right;
+      width: 14em;
+    }
+  }
+}

--- a/app/controllers/concerns/spreadsheet_readable.rb
+++ b/app/controllers/concerns/spreadsheet_readable.rb
@@ -1,0 +1,27 @@
+module SpreadsheetReadable
+  extend ActiveSupport::Concern
+
+  private
+
+  # Spreadsheetのセルの値を、座標を指定して取得する
+  # @param [Spreadsheet::Worksheet] sheet
+  # @param [String] address セルの座標。 ex) 'S17', 'AA5'
+  # @param [String | Integer | Float] default_value セルが空だったときに返す値
+  # @return [String | Integer | Float | nil] セルに入っている値
+  def read(sheet, address, default_value = nil)
+    md = address.match(/\A([A-Z]+)(\d+)\z/)
+    col = md[2].to_i - 1
+    row = 0
+    # 'A'.ord #=> 65
+    md[1].reverse.split('').each_with_index do |c, i|
+      row += (c.ord - 64) * (26 ** i)
+    end
+    row -= 1
+    begin
+      cell = sheet.cell(col, row)
+      cell.respond_to?(:value) ? cell.value : (cell || default_value)
+    rescue => ex
+      default_value
+    end
+  end
+end

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -1,4 +1,6 @@
 class EstimatesController < ApplicationController
+  include SpreadsheetReadable
+
   before_action :authenticate_user!
 
   layout 'admin'
@@ -68,22 +70,5 @@ class EstimatesController < ApplicationController
       *%i(project_id subject estimated_on serial_no amount
           director_manday engineer_manday designer_manday other_manday cost filename)
     )
-  end
-
-  def read(sheet, address, default_value = nil)
-    md = address.match(/\A([A-Z]+)(\d+)\z/)
-    col = md[2].to_i - 1
-    row = 0
-    # 'A'.ord #=> 65
-    md[1].reverse.split('').each_with_index do |c, i|
-      row += (c.ord - 64) * (26 ** i)
-    end
-    row -= 1
-    begin
-      cell = sheet.cell(col, row)
-      cell.respond_to?(:value) ? cell.value : (cell || default_value)
-    rescue => ex
-      default_value
-    end
   end
 end

--- a/app/controllers/estimates_controller.rb
+++ b/app/controllers/estimates_controller.rb
@@ -39,7 +39,7 @@ class EstimatesController < ApplicationController
 
     @warnings = []
     if Estimate.exists?(serial_no: @resource.serial_no)
-      @warnings << '見積書NOが重複しています。'
+      @warnings << '見積書NOが重複しています。登録内容は上書きされます。'
     end
     if @resource.too_old?
       @warnings << '見積もり日付が半年以上前です。'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -55,6 +55,7 @@ class ProjectsController < ApplicationController
   # プロジェクト詳細
   def show
     authorize @project
+    @estimates = @project.estimates.to_a
   end
 
   # プロジェクト編集

--- a/app/javascript/packs/estimates.jsx
+++ b/app/javascript/packs/estimates.jsx
@@ -1,0 +1,259 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const csrfToken = document.getElementsByName('csrf-token').item(0).content;
+const requestParams = {
+  credentials: 'same-origin',
+  headers: {
+    'Accept': 'application/json',
+    'X-CSRF-Token': csrfToken
+  }
+};
+
+class Estimate extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      resource: null,
+      warnings: [],
+      error: null
+    };
+  }
+
+  confirm(formData) {
+    fetch(this.props.confirmEstimatesPath, Object.assign(requestParams, { method: 'POST', body: formData }))
+      .then(response => response.json())
+      .then(response => {
+        if (response.status === 'ok') {
+          this.setState({ resource: response.resource, warnings: response.warnings, error: null })
+        } else {
+          this.setState({ resource: null, error: response.error });
+        }
+      });
+  }
+
+  cancel() {
+    this.setState({ resource: null, warnings: [], error: null });
+  }
+
+  render() {
+    if (this.state.resource) {
+      return <EstimateForm action={this.props.estimatesPath}
+                           resource={this.state.resource}
+                           warnings={this.state.warnings}
+                           onCancel={this.cancel.bind(this)} />;
+    } else {
+      return <EstimateConfirmForm action={this.props.confirmEstimatesPath}
+                                  error={this.state.error}
+                                  onSubmit={this.confirm.bind(this)} />;
+    }
+  }
+}
+
+/**
+ * 確認表示をするためのフォーム
+ */
+class EstimateConfirmForm extends React.Component {
+  openFileDialog(event) {
+    event.preventDefault();
+    this.refs.fileButton.click();
+  }
+
+  handleDragOver(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.target.classList.add('dragover');
+  }
+
+  handleDragEnter(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.target.classList.add('dragover');
+  }
+
+  handleDragLeave(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.target.classList.remove('dragover');
+  }
+
+  handleDrop(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.target.classList.remove('dragover');
+
+    let file = event.dataTransfer.files[0];
+    let form = this.refs.form;
+    let formData = new FormData(form);
+    formData.append('file', file);
+    this.props.onSubmit(formData);
+  }
+
+  handleChange(event) {
+    this.props.onSubmit(new FormData(this.refs.form));
+  }
+
+  render() {
+    return <form action={this.props.action} method="POST" encType="multipart/form-data" ref="form">
+      {this.props.error &&
+        <div className="alert alert-danger">{this.props.error}</div>
+      }
+      <div className="panel panel-default drop-area"
+           onDragOver={this.handleDragOver.bind(this)}
+           onDragEnter={this.handleDragEnter.bind(this)}
+           onDragLeave={this.handleDragLeave.bind(this)}
+           onDrop={this.handleDrop.bind(this)}>
+        <div className="panel-body">
+          <p>
+            <a href="#" onClick={this.openFileDialog.bind(this)}>ファイルを選択</a>
+            または、見積書ファイルをここにドラッグ ＆ ドロップ
+          </p>
+        </div>
+      </div>
+      <input type="file" name="file" ref="fileButton" className="hidden" onChange={this.handleChange.bind(this)} />
+    </form>;
+  }
+}
+
+/**
+ * データを登録するためのフォーム
+ */
+class EstimateForm extends React.Component {
+  cancel(event) {
+    event.preventDefault();
+    this.props.onCancel();
+  }
+
+  render() {
+    let warnings = null;
+    if (this.props.warnings && this.props.warnings.length > 0) {
+      warnings = <EstimateWarnings warnings={this.props.warnings} />;
+    }
+    return <form action={this.props.action} method="POST">
+      <input type="hidden" name="authenticity_token" value={csrfToken} />
+      <p>この内容で良ければ、登録ボタンを押してください。</p>
+      {warnings}
+      <EstimateTable resource={this.props.resource} />
+      <EstimateHiddenFields resource={this.props.resource} />
+      <div className="form-group text-center">
+        <input type="submit" value="登録" className="btn btn-primary navbar-btn" />
+        <input type="reset" value="中止" className="btn btn-danger navbar-btn" onClick={this.cancel.bind(this)} />
+      </div>
+    </form>;
+  }
+}
+
+/**
+ * 登録しようとしているデータに対しての警告表示
+ */
+class EstimateWarnings extends React.Component {
+  render() {
+    return (
+      <div className="panel panel-warning">
+        <div className="panel-heading">
+          <h3 className="panel-title">警告</h3>
+        </div>
+        <div className="panel-body">
+          {this.props.warnings.map((warning, i) => {
+            return <p key={"warning" + i}>{warning}</p>;
+          })}
+        </div>
+      </div>
+    );
+  }
+}
+
+/**
+ * 登録しようとしているデータを表示
+ */
+class EstimateTable extends React.Component {
+  render() {
+    let estimate = this.props.resource;
+    return (
+      <table className="table confirm">
+        <tbody>
+          <tr>
+            <th>PJコード</th>
+            <td>{estimate.project_code}</td>
+          </tr>
+          <tr>
+            <th>プロジェクト名</th>
+            <td>{estimate.project_name}</td>
+          </tr>
+          <tr>
+            <th>見積もり件名</th>
+            <td>{estimate.subject}</td>
+          </tr>
+          <tr>
+            <th>見積書NO</th>
+            <td>{estimate.serial_no}</td>
+          </tr>
+          <tr>
+            <th>見積もり日付</th>
+            <td>{estimate.estimated_on}</td>
+          </tr>
+          <tr>
+            <th>見積もり金額</th>
+            <td>¥{estimate.amount.toLocaleString()}</td>
+          </tr>
+          <tr>
+            <th>営業・ディレクター想定工数</th>
+            <td>{estimate.director_manday} 人/日</td>
+          </tr>
+          <tr>
+            <th>エンジニア想定工数</th>
+            <td>{estimate.engineer_manday} 人/日</td>
+          </tr>
+          <tr>
+            <th>デザイナー想定工数</th>
+            <td>{estimate.designer_manday} 人/日</td>
+          </tr>
+          <tr>
+            <th>その他想定工数</th>
+            <td>{estimate.other_manday} 人/日</td>
+          </tr>
+          <tr>
+            <th>予定原価</th>
+            <td>¥{estimate.cost.toLocaleString()}</td>
+          </tr>
+          <tr>
+            <th>見積書ファイル名</th>
+            <td>{estimate.filename}</td>
+          </tr>
+        </tbody>
+      </table>
+    );
+  }
+}
+
+/**
+ * サーバーに送信するためのinputタグ
+ */
+class EstimateHiddenFields extends React.Component {
+  render() {
+    let estimate = this.props.resource;
+    let fields = ['project_id', 'subject', 'estimated_on', 'serial_no', 'amount',
+      'director_manday', 'engineer_manday', 'designer_manday', 'other_manday', 'cost', 'filename'].map((attribute, i) => {
+      return <input type="hidden"
+                    name={"estimate[" + attribute + "]"}
+                    value={estimate[attribute]}
+                    key={"value" + i} />;
+    });
+    return <div>{fields}</div>;
+  }
+}
+
+Turbolinks.start();
+
+document.addEventListener('turbolinks:load', () => {
+  let container = document.getElementById('estimates');
+  ReactDOM.render(
+    <Estimate estimatesPath={container.dataset.estimatesPath}
+              confirmEstimatesPath={container.dataset.confirmEstimatesPath} />,
+    container
+  );
+});
+
+document.addEventListener('turbolinks:before-render', () => {
+  ReactDOM.unmountComponentAtNode(document.getElementById('estimates'));
+});

--- a/app/models/estimate.rb
+++ b/app/models/estimate.rb
@@ -1,0 +1,36 @@
+class EstimateValidator < ActiveModel::Validator
+  def validate(record)
+    if record.director_manday + record.engineer_manday + record.designer_manday + record.other_manday <= 0.0
+      record.errors.add(:base, '工数の合計がゼロです。')
+    end
+  end
+end
+
+class Estimate < ApplicationRecord
+  belongs_to :project
+
+  validates :subject, presence: true
+  validates :serial_no, presence: true
+  validates :amount, numericality: { greater_than: 0 }
+  validates :filename, presence: true
+
+  validates_with EstimateValidator
+
+  # 過去に全く同じ工数・原価設定があるか調べる
+  # @return [Boolean]
+  def deja_vu?
+    self.class.where(
+      director_manday: self.director_manday,
+      engineer_manday: self.engineer_manday,
+      designer_manday: self.designer_manday,
+      cost: self.cost
+    ).exists?
+  end
+
+  # 見積もり日付が半年以上前か？
+  # @param [Date] on 判定基準となる日付
+  # @return [Boolean]
+  def too_old?(on = Time.current.to_date)
+    on - self.estimated_on > 180
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@ class Project < ApplicationRecord
   has_many :operations
   has_many :user_projects, dependent: :destroy
   has_many :users, through: :user_projects
+  has_many :estimates
 
   validates :code,
     allow_blank: true,

--- a/app/policies/estimate_polity.rb
+++ b/app/policies/estimate_polity.rb
@@ -1,0 +1,13 @@
+class EstimatePolicy < ApplicationPolicy
+  def index?
+    @user&.administrator? || @user&.director?
+  end
+
+  def confirm?
+    index?
+  end
+
+  def create?
+    index?
+  end
+end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -7,6 +7,10 @@ class ProjectPolicy < ApplicationPolicy
     @user.administrator? || @user.director?
   end
 
+  def show?
+    create?
+  end
+
   def edit?
     create?
   end

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -5,6 +5,9 @@ dl.dl-horizontal
     = link_to 'プロジェクト管理', projects_path
   dd 日報に登録するプロジェクトを管理します。
   dt
+    = link_to '見積書アップロード', estimates_path
+  dd 見積書ファイルをアップロードします。
+  dt
     = link_to_if policy(current_user).index?, 'ユーザー管理', users_path
   dd ユーザーの一覧を表示し、登録や編集を行います。
   dt

--- a/app/views/estimates/confirm.json.jbuilder
+++ b/app/views/estimates/confirm.json.jbuilder
@@ -1,0 +1,24 @@
+if @error.blank?
+  json.status 'ok'
+  json.resource do
+    json.project_id @resource.project_id
+    json.project_code @resource.project.code
+    json.project_name @resource.project.name
+    json.subject @resource.subject
+    json.estimated_on @resource.estimated_on
+    json.serial_no @resource.serial_no
+    json.amount @resource.amount
+    json.director_manday @resource.director_manday
+    json.engineer_manday @resource.engineer_manday
+    json.designer_manday @resource.designer_manday
+    json.other_manday @resource.other_manday
+    json.cost @resource.cost
+    json.filename @resource.filename
+  end
+  unless @warnings.blank?
+    json.warnings @warnings
+  end
+else
+  json.status 'error'
+  json.error @error
+end

--- a/app/views/estimates/index.html.slim
+++ b/app/views/estimates/index.html.slim
@@ -1,0 +1,11 @@
+- breadcrumb :estimates
+
+h1 見積書アップロード
+
+= render_flash_message
+
+#estimates[data-estimates-path=estimates_path(format: :json)
+           data-confirm-estimates-path=confirm_estimates_path(format: :json)]
+
+- content_for :foot do
+  = javascript_pack_tag 'estimates', 'data-turbolinks-track': 'reload'

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -4,18 +4,18 @@
 .page-header
   h1 プロジェクト詳細
 
-dl.row
-  dt.col-sm-2= t('project.code')
-  dd.col-sm-10= @project.code || '（未設定）'
+dl.dl-horizontal
+  dt= t('project.code')
+  dd= @project.code || '（未設定）'
 
-  dt.col-sm-2= t('project.name')
-  dd.col-sm-10= text_with_ruby(@project.name, @project.name_reading)
+  dt= t('project.name')
+  dd= text_with_ruby(@project.name, @project.name_reading)
 
-  dt.col-sm-2= t('project.category')
-  dd.col-sm-10= @project.category_i18n
+  dt= t('project.category')
+  dd= @project.category_i18n
 
-  dt.col-sm-2= t('project.displayed')
-  dd.col-sm-10
+  dt= t('project.displayed')
+  dd
     = display_status(@project)
     = @project.display_status
 
@@ -48,3 +48,31 @@ h2 このプロジェクトの日報を投稿したメンバー
   .collapse.navbar-collapse
     .nav.navbar-nav
       = link_to 'このプロジェクトのメンバーを編集', project_members_path(@project.id), class: 'btn btn-primary navbar-btn'
+
+- if @estimates.present?
+  h2 見積もり情報
+
+  table.table style="table-layout:fixed"
+    tr
+      th.text-right style="width:16em"= t('estimate.subject')
+      td= @estimates.first.subject
+    tr
+      th.text-right= t('project.estimate.amount')
+      td= "¥#{@estimates.sum{ |e| e.amount }.to_s(:delimited)}"
+    tr
+      th.text-right= t('project.estimate.director_manday')
+      td= "#{@estimates.sum{ |e| e.director_manday }} 人/日"
+    tr
+      th.text-right= t('project.estimate.engineer_manday')
+      td= "#{@estimates.sum { |e| e.engineer_manday }} 人/日"
+    tr
+      th.text-right= t('project.estimate.designer_manday')
+      td= "#{@estimates.sum { |e| e.designer_manday }} 人/日"
+    tr
+      th.text-right= t('project.estimate.other_manday')
+      td= "#{@estimates.sum { |e| e.other_manday }} 人/日"
+    tr
+      th.text-right= t('project.estimate.cost')
+      td= "¥#{@estimates.sum { |e| e.cost }.to_s(:delimited)}"
+
+h2 請求情報

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -45,6 +45,15 @@ crumb :unsubmitted do
   link '日報未提出一覧', unsubmitted_path
 end
 
+crumb :estimates do
+  link '見積書アップロード', estimates_path
+end
+
+crumb :estimate_import_confirm do
+  link '見積書アップロードプレビュー', import_confirm_estimates_path
+  parent :estimates
+end
+
 # crumb :project_issues do |project|
 #   link "Issues", project_issues_path(project)
 #   parent :project, project

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -29,10 +29,29 @@ ja:
     code: PJコード
     name: プロジェクト名
     name_reading: 読みかな
-    category: 種別
+    category: PJ種別
     displayed: 表示ステータス
     hidden: 非表示
+    estimate:
+      amount: 見積もり金額合計
+      director_manday: 営業・ディレクター想定工数合計
+      engineer_manday: エンジニア想定工数合計
+      designer_manday: デザイナー想定工数合計
+      other_manday: その他想定工数合計
+      cost: 予定原価合計
     created_at: 作成日
+
+  estimate: &estimate_attributes
+    subject: 見積もり件名
+    estimated_on: 見積もり日付
+    serial_no: 見積書NO
+    amount: 見積もり金額
+    director_manday: 営業・ディレクター想定工数
+    engineer_manday: エンジニア想定工数
+    designer_manday: デザイナー想定工数
+    other_manday: その他想定工数
+    cost: 予定原価
+    filename: 見積書ファイル名
 
   activerecord: &activerecord
     models:
@@ -41,6 +60,7 @@ ja:
       project: プロジェクト
       operation: 稼働内容
       report: 日報
+      estimate: 見積書
     attributes:
       user:
         <<: *user_attributes
@@ -48,6 +68,8 @@ ja:
         <<: *user_role_attributes
       project:
         <<: *project_attributes
+      estimate:
+        <<: *estimate_attributes
 
   activemodel:
     <<: *activerecord

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,11 @@ Rails.application.routes.draw do
   resources :projects do
     resources :members, only: %i(index update destroy), module: :projects
   end
+  resources :estimates, only: %i(index create) do
+    collection do
+      post :confirm
+    end
+  end
 
   namespace :settings do
     resources :projects, only: %i(index update destroy)

--- a/db/migrate/20171113121205_create_estimates.rb
+++ b/db/migrate/20171113121205_create_estimates.rb
@@ -1,0 +1,20 @@
+class CreateEstimates < ActiveRecord::Migration[5.1]
+  def change
+    create_table :estimates do |t|
+      t.references :project
+      t.string :serial_no
+      t.string :subject
+      t.integer :amount, default: 0
+      t.float :director_manday, default: 0.0
+      t.float :engineer_manday, default: 0.0
+      t.float :designer_manday, default: 0.0
+      t.float :other_manday, default: 0.0
+      t.integer :cost, default: 0
+      t.date :estimated_on
+      t.string :filename
+      t.timestamps
+
+      t.index :serial_no, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171113072354) do
+ActiveRecord::Schema.define(version: 20171113121205) do
+
+  create_table "estimates", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.bigint "project_id"
+    t.string "serial_no"
+    t.string "subject"
+    t.integer "amount", default: 0
+    t.float "director_manday", limit: 24, default: 0.0
+    t.float "engineer_manday", limit: 24, default: 0.0
+    t.float "designer_manday", limit: 24, default: 0.0
+    t.float "other_manday", limit: 24, default: 0.0
+    t.integer "cost", default: 0
+    t.date "estimated_on"
+    t.string "filename"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_estimates_on_project_id"
+    t.index ["serial_no"], name: "index_estimates_on_serial_no", unique: true
+  end
 
   create_table "operations", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "report_id"

--- a/spec/controllers/estimates_controller_spec.rb
+++ b/spec/controllers/estimates_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EstimatesController, type: :controller do
+
+end

--- a/spec/factories/estimates.rb
+++ b/spec/factories/estimates.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :estimate do
+    
+  end
+end

--- a/spec/models/estimate_spec.rb
+++ b/spec/models/estimate_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Estimate, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## このPRで解決される問題

- 見積書`Estimate`モデルを定義する
- 見積書Excelファイルをアップロードし、データ登録ができるようにする。
    - ドラッグ＆ドロップによるファイルアップロードに対応している。
    - 見積書NOが重複している場合、データは上書きで登録される。（その旨、警告が出る）
- 見積データはプロジェクトごとに値を合算されたものをプロジェクト詳細ページで閲覧可能

Issue: #43 