### PR TITLE
fix projects_summary

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -28,6 +28,7 @@ class ReportsController < ApplicationController
         end
         @reports = Report.includes(:user).joins(:user)
           .where(worked_in: [start_on..end_on])
+          .merge(User.available)
           .order('users.id', worked_in: :asc)
         send_data render_to_string,
                   filename: "dailyreport_#{start_on.strftime('%Y%m%d')}-#{end_on.strftime('%Y%m%d')}.csv",

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,7 +4,7 @@ module UsersHelper
       form_with model: user, method: :delete do |f|
         f.submit('このユーザーを集計対象から外す',
                  class: 'btn btn-danger navbar-btn',
-                 data: { confirm: "このユーザーを集計対象から外します。\n全てのプロジェクトからこのユーザーの関連付けが削除されます。\nよろしいですか？" })
+                 data: { confirm: "このユーザーを集計対象から外します。よろしいですか？" })
       end
     else
       form_with model: user, url: revive_user_path(user), method: :patch do |f|

--- a/app/javascript/packs/bills.jsx
+++ b/app/javascript/packs/bills.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import Turbolinks from 'turbolinks'
 
 const csrfToken = document.getElementsByName('csrf-token').item(0).content;
 const requestParams = {

--- a/app/javascript/packs/estimates.jsx
+++ b/app/javascript/packs/estimates.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import Turbolinks from 'turbolinks'
 
 const csrfToken = document.getElementsByName('csrf-token').item(0).content;
 const requestParams = {

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -35,13 +35,13 @@ class Report < ApplicationRecord
     # 指定した期間内に日報を提出したユーザーの配列を返す
     # @param [Date] start_on
     # @param [Date] end_on
-    # @return [Array]
+    # @return [Array] users
     def submitted_users(start_on, end_on)
       user_ids = where(worked_in: [start_on..end_on])
                    .select(:user_id)
                    .uniq
                    .pluck(:user_id)
-      User.where(id: user_ids)
+      User.available.where(id: user_ids)
     end
 
     # 該当のユーザーが指定期間内で日報未提出の日付を返す

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -4,12 +4,13 @@ dl.dl-horizontal
   dt
     = link_to 'プロジェクト管理', projects_path
   dd 日報に登録するプロジェクトを管理します。
-  dt
-    = link_to '見積書アップロード', estimates_path
-  dd 見積書ファイルをアップロードします。
-  dt
-    = link_to '請求書アップロード', bills_path
-  dd 請求書ファイルをアップロードします。
+  /
+    dt
+      = link_to '見積書アップロード', estimates_path
+    dd 見積書ファイルをアップロードします。
+    dt
+      = link_to '請求書アップロード', bills_path
+    dd 請求書ファイルをアップロードします。
   dt
     = link_to_if policy(current_user).index?, 'ユーザー管理', users_path
   dd ユーザーの一覧を表示し、登録や編集を行います。

--- a/app/views/bills/index.html.slim
+++ b/app/views/bills/index.html.slim
@@ -7,5 +7,8 @@ h1 請求書アップロード
 #bills[data-bills-path=bills_path(format: :json)
        data-confirm-bills-path=confirm_bills_path(format: :json)]
 
+div
+  | ※何も表示されなかったらリロードしてみてください。
+
 - content_for :foot do
   = javascript_pack_tag 'bills'

--- a/app/views/estimates/index.html.slim
+++ b/app/views/estimates/index.html.slim
@@ -1,4 +1,4 @@
-- breadcrumb :estimates
+g- breadcrumb :estimates
 
 h1 見積書アップロード
 
@@ -6,6 +6,9 @@ h1 見積書アップロード
 
 #estimates[data-estimates-path=estimates_path(format: :json)
            data-confirm-estimates-path=confirm_estimates_path(format: :json)]
+
+div
+  | ※何も表示されなかったらリロードしてみてください。
 
 - content_for :foot do
   = javascript_pack_tag 'estimates'

--- a/app/views/projects/_form.html.slim
+++ b/app/views/projects/_form.html.slim
@@ -14,14 +14,15 @@
     .col-sm-10
       = f.text_field :name_reading, class: 'form-control'
       = error_message project, :name_reading
-  .form-group
-    label.col-sm-2.control-label= t('project.category')
-    .col-sm-10
-      - Project.categories_i18n.each do |key, value|
-        - next if key == 'undefined'
-        label.radio-inline
-          = f.radio_button :category, key
-          = value
+  /
+    .form-group
+      label.col-sm-2.control-label= t('project.category')
+      .col-sm-10
+        - Project.categories_i18n.each do |key, value|
+          - next if key == 'undefined'
+          label.radio-inline
+            = f.radio_button :category, key
+            = value
   .form-group
     .col-sm-offset-2.col-sm-10
       .checkbox

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -36,14 +36,15 @@
         label.checkbox-inline
           = check_box_tag 'user_roles[]', value, user.user_roles.any?{ |u| u.send("#{role}?") }
           span.label.label-primary= t("user_role.#{role}")
-  .form-group
-    label.col-sm-2.control-label= t('user.division')
-    .col-sm-10
-      - User.divisions_i18n.each do |key, value|
-        - next if key == 'undefined'
-        label.radio-inline
-          = f.radio_button :division, key
-          span class="label label-#{key}"= value
+  /
+    .form-group
+      label.col-sm-2.control-label= t('user.division')
+      .col-sm-10
+        - User.divisions_i18n.each do |key, value|
+          - next if key == 'undefined'
+          label.radio-inline
+            = f.radio_button :division, key
+            span class="label label-#{key}"= value
   .form-group
     .col-sm-offset-2.col-sm-10
       = f.submit user.new_record? ? '登録' : '更新', class: 'btn btn-default'

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -21,7 +21,7 @@ table.table.table-hover#users
     th= t('user.name')
     th= t('user.email')
     th= t('user.began_on')
-    th= t('user.division')
+    / th= t('user.division')
     th= t('user.available')
     th= t('user.role')
   - @users.each do |user|
@@ -30,6 +30,6 @@ table.table.table-hover#users
       td= link_to user.name, edit_user_path(user.id)
       td= user.email
       td= user.began_on&.strftime('%Y/%m/%d')
-      td= content_tag(:span, user.division_i18n, class: "label label-#{user.division}")
+      / td= content_tag(:span, user.division_i18n, class: "label label-#{user.division}")
       td= available_label(user)
       td= role_labels(user)

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -14,7 +14,7 @@ ja:
     began_on: 日報集計開始日
     status:
       available: 集計中
-      deleted: 削除済
+      deleted: 対象外
 
   user_role: &user_role_attributes
     administrator: 管理者


### PR DESCRIPTION
# 概要
- ユーザーを集計対象から除外してもプロジェクト工数データを削除しなくなったため、実情に合わせて除外前に出てくる確認メッセージを修正。
- 稼働集計の表示時、集計対象から除外されたユーザーの工数を表示しないように変更。
- 未実装の項目について、管理画面に表示しないようにする。
    - 見積書・請求書のアップロード
    - ユーザーの職種
    - プロジェクトの種別

## Issue
#71 