### PR TITLE
post unsubmitted list to Slack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem 'enum_help'
 gem 'spreadsheet'
 gem 'roo-xls'
 
+# Use slack-notifier to send notifications to Slack webhooks
+gem 'slack-notifier'
+
 group :development, :test do
   gem 'rspec-rails'
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    slack-notifier (2.3.2)
     slim (3.0.8)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
@@ -344,6 +345,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 5.0)
+  slack-notifier
   slim-rails
   spreadsheet
   spring

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,4 +29,5 @@ services:
       DB_PASSWORD:
       BUGSNAG_API_KEY:
       BUGSNAG_ENV:
+      SLACK_WEBHOOK_URL:
     command: /bin/bash -c "bin/rails s -b 0.0.0.0 -p 3000"

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -126,14 +126,19 @@ namespace :app do
     end
   end
 
-  desc '日報未提出者の一覧をSlack#generalに送信する'
-  task unsubmitted_notification_slack: :environment do
+  desc '日報未提出者の一覧をSlackに送信する。送信先のchannelは引数で設定可'
+  task :unsubmitted_notification_slack, ['channel'] => :environment do |task, args|
     today = Date.today
     start_on = today.ago(40.days).to_datetime
     end_on = today.yesterday.to_datetime
-    notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'] do
-      defaults channel: '#times_kibihara', username: 'daily-report'
+    if args[:channel].present?
+      notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'] do
+        defaults channel: args[:channel]
+      end
+    else
+      notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL']
     end
+
     text = <<-EOS
 日報が未提出の方がいます。
 以下、ご確認ください。

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -126,6 +126,31 @@ namespace :app do
     end
   end
 
+  desc '日報未提出者の一覧をSlack#generalに送信する'
+  task unsubmitted_notification_slack: :environment do
+    today = Date.today
+    start_on = today.ago(40.days).to_datetime
+    end_on = today.yesterday.to_datetime
+    notifier = Slack::Notifier.new ENV['SLACK_WEBHOOK_URL'] do
+      defaults channel: '#times_kibihara', username: 'daily-report'
+    end
+    text = <<-EOS
+日報が未提出の方がいます。
+以下、ご確認ください。
+※休みの場合も休み明けに「休み」を設定してください。
+    EOS
+    User.available.each do |user|
+      dates = Report.unsubmitted_dates(user.id, start_on: start_on, end_on: end_on).map(&:to_s)
+      next if dates.blank?
+      text << "・#{user.name}\n"
+      dates.each do |date|
+        text << "#{date}\n"
+      end
+      text << "\n"
+    end
+    notifier.ping text
+  end
+
   desc '請求書シート読み取りテスト'
   task :spreadsheet_test do
     book = Spreadsheet.open Rails.root.join('tmp', 'bill.xls')

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -138,13 +138,18 @@ namespace :app do
 日報が未提出の方がいます。
 以下、ご確認ください。
 ※休みの場合も休み明けに「休み」を設定してください。
+
     EOS
     User.available.each do |user|
       dates = Report.unsubmitted_dates(user.id, start_on: start_on, end_on: end_on).map(&:to_s)
       next if dates.blank?
       text << "・#{user.name}\n"
       dates.each do |date|
-        text << "#{date}\n"
+        if date.is_a?(Date)
+          text << date.strftime('%Y-%m-%d')
+        else
+          text << "#{date.split('T').first}\n"
+        end
       end
       text << "\n"
     end


### PR DESCRIPTION
# 概要

SlackのIncomming Webhookを利用し、日報未提出者の一覧をSlackに投稿するRake taskを追加する。
対象期間は昨日〜40日前。

環境変数 `SLACK_WEBHOOK_URL` に、SlackのWebhookのURLを設定すること。

## Issue
#74