### PR TITLE
fix mysql version to 5.7 on docker

### DIFF
--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:latest
+FROM mysql:5.7
 
 # Set debian default locale to ja_JP.UTF-8
 RUN apt-get update -qq && \


### PR DESCRIPTION
# 概要
latestだと8.0.13が入り、Railsから接続時に、

> Mysql2::Error: Authentication plugin 'caching_sha2_password' cannot be loaded

というエラーが出ていたため、5.7を使うことを明示した。

## Issue
#88