### PR TITLE
Fix summary report to change character set.

### DIFF
--- a/app/views/reports/summaries/show.csv.ruby
+++ b/app/views/reports/summaries/show.csv.ruby
@@ -1,6 +1,6 @@
 require 'csv'
 
-CSV.generate(encoding: 'Shift_JIS') do |csv|
+CSV.generate(encoding: 'SJIS') do |csv|
   header = %w(PJコード プロジェクト名)
   @users.each do |user|
     header << user.name


### PR DESCRIPTION
## このPRで修正される問題

プロジェクト名などにUTF-8 -> Shift_JISの変換に失敗するような文字が含まれていた場合、稼働集計のCSV出力に失敗する不具合を修正した。

関連Issue: #85 