### PR TITLE
feat: ローカル開発環境用Docker Compose設定の追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# データベース設定
+DB_HOST=db
+DB_USERNAME=root
+DB_PASSWORD=password
+DB_PORT=3306
+
+# MySQL設定
+MYSQL_USER=root
+MYSQL_PASSWORD=password
+MYSQL_HOST=db
+MYSQL_PORT=3306
+
+# Rails設定
+RAILS_ENV=development
+RAILS_LOG_TO_STDOUT=true
+RAILS_SERVE_STATIC_FILES=true
+
+# Webpacker設定
+NODE_ENV=development
+WEBPACKER_DEV_SERVER_HOST=0.0.0.0
+
+# 外部サービス設定（必要に応じて設定）
+BUGSNAG_API_KEY=
+BUGSNAG_ENV=development
+SLACK_WEBHOOK_URL=
+
+# その他の設定
+BUNDLER_VERSION=2.4.22
+BOOTSNAP_CACHE_DIR=/tmp/bootsnap-cache

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 
+# 環境変数ファイル
+.env
+.env.local
+
 /.idea
 
 # Ignore master key for decrypting credentials and more.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,82 @@
+.PHONY: help setup build up down restart logs console test clean
+
+# デフォルトのdocker-composeファイル
+DC = docker-compose -f docker-compose.dev.yml
+
+help: ## ヘルプを表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+setup: ## 開発環境をセットアップ
+	@./scripts/setup-dev.sh
+
+build: ## Dockerイメージをビルド
+	$(DC) build
+
+up: ## コンテナを起動
+	$(DC) up -d
+
+down: ## コンテナを停止
+	$(DC) down
+
+restart: ## コンテナを再起動
+	$(DC) restart
+
+logs: ## ログを表示（tail -f）
+	$(DC) logs -f
+
+app-logs: ## アプリケーションのログのみ表示
+	$(DC) logs -f app
+
+db-logs: ## データベースのログのみ表示
+	$(DC) logs -f db
+
+console: ## Rails consoleを起動
+	$(DC) exec app bundle exec rails console
+
+db-console: ## MySQLコンソールを起動
+	$(DC) exec db mysql -u root -ppassword daily_report_development
+
+migrate: ## マイグレーションを実行
+	$(DC) exec app bundle exec rails db:migrate
+
+rollback: ## マイグレーションをロールバック
+	$(DC) exec app bundle exec rails db:rollback
+
+seed: ## シードデータを投入
+	$(DC) exec app bundle exec rails db:seed
+
+test: ## テストを実行
+	docker-compose -f docker-compose.test.yml run --rm app-test
+
+test-watch: ## テストを監視モードで実行
+	$(DC) exec app bundle exec guard
+
+rubocop: ## Rubocopを実行
+	$(DC) exec app bundle exec rubocop
+
+rubocop-fix: ## Rubocopで自動修正
+	$(DC) exec app bundle exec rubocop -a
+
+routes: ## ルーティングを表示
+	$(DC) exec app bundle exec rails routes
+
+bundle: ## bundle installを実行
+	$(DC) exec app bundle install
+
+yarn: ## yarn installを実行
+	$(DC) exec app yarn install
+
+webpack: ## Webpackをビルド
+	$(DC) exec app ./bin/webpack
+
+webpack-dev: ## webpack-dev-serverを起動
+	$(DC) exec webpacker ./bin/webpack-dev-server
+
+clean: ## コンテナとボリュームを削除（注意：データも削除されます）
+	$(DC) down -v
+
+attach: ## appコンテナにアタッチ
+	$(DC) exec app bash
+
+ps: ## コンテナの状態を表示
+	$(DC) ps

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 [Docker](https://www.docker.com/)と[Docker Compose](https://docs.docker.com/compose/)を利用しています。
 
+### 🚀 クイックスタート（推奨）
+
+開発環境を簡単にセットアップできるスクリプトを用意しています：
+
+```bash
+./scripts/setup-dev.sh
+```
+
+詳細な手順については[開発環境セットアップガイド](docs/development-setup.md)を参照してください。
+
+### 従来の手動セットアップ
+
 ### 初回セットアップ
 
 1. イメージのビルド

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,84 @@
+version: '3.7'
+
+services:
+  db:
+    image: mysql:5.7
+    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    volumes:
+      - mysql-db-dev:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: daily_report_development
+      MYSQL_USER: daily_report
+      MYSQL_PASSWORD: password
+    ports:
+      - "3307:3306"  # ホストのMySQLと競合しないようにポートを変更
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 5s
+      retries: 10
+
+  app:
+    build:
+      context: .
+      dockerfile: ./docker/rails/Dockerfile.dev
+    volumes:
+      - .:/daily-report
+      - rubygems-dev:/usr/local/bundle
+      - node_modules:/daily-report/node_modules  # node_modulesを永続化
+    ports:
+      - "3000:3000"
+      - "3035:3035"  # webpack-dev-server用
+    depends_on:
+      - db
+    environment:
+      RAILS_ENV: development
+      NODE_ENV: development
+      MYSQL_USER: root
+      MYSQL_PASSWORD: password
+      MYSQL_HOST: db
+      MYSQL_PORT: 3306
+      DB_HOST: db
+      DB_USERNAME: root
+      DB_PASSWORD: password
+      DB_PORT: 3306
+      BUNDLER_VERSION: 2.4.22
+      WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
+      BOOTSNAP_CACHE_DIR: /tmp/bootsnap-cache
+      EDITOR: vim
+    stdin_open: true
+    tty: true
+    command: >
+      bash -c "
+        rm -f tmp/pids/server.pid &&
+        bundle install &&
+        yarn install &&
+        bundle exec rails db:create db:migrate &&
+        bundle exec rails server -b 0.0.0.0
+      "
+
+  webpacker:
+    build:
+      context: .
+      dockerfile: ./docker/rails/Dockerfile.dev
+    volumes:
+      - .:/daily-report
+      - rubygems-dev:/usr/local/bundle
+      - node_modules:/daily-report/node_modules
+    ports:
+      - "3035:3035"
+    depends_on:
+      - app
+    environment:
+      RAILS_ENV: development
+      NODE_ENV: development
+      WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
+    command: ./bin/webpack-dev-server
+
+volumes:
+  rubygems-dev:
+    driver: 'local'
+  mysql-db-dev:
+    driver: 'local'
+  node_modules:
+    driver: 'local'

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,47 @@
+version: '3.7'
+
+services:
+  db-test:
+    image: mysql:5.7
+    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: daily_report_test
+      MYSQL_USER: daily_report
+      MYSQL_PASSWORD: password
+    tmpfs:
+      - /var/lib/mysql  # テスト用にメモリ上にデータベースを構築
+
+  app-test:
+    build:
+      context: .
+      dockerfile: ./docker/rails/Dockerfile.dev
+    volumes:
+      - .:/daily-report
+      - rubygems-test:/usr/local/bundle
+    depends_on:
+      - db-test
+    environment:
+      RAILS_ENV: test
+      NODE_ENV: test
+      MYSQL_USER: root
+      MYSQL_PASSWORD: password
+      MYSQL_HOST: db-test
+      MYSQL_PORT: 3306
+      DB_HOST: db-test
+      DB_USERNAME: root
+      DB_PASSWORD: password
+      DB_PORT: 3306
+      BUNDLER_VERSION: 2.4.22
+      DISABLE_SPRING: 1
+    command: >
+      bash -c "
+        bundle install &&
+        yarn install &&
+        bundle exec rails db:create db:migrate &&
+        bundle exec rspec
+      "
+
+volumes:
+  rubygems-test:
+    driver: 'local'

--- a/docker/rails/Dockerfile.dev
+++ b/docker/rails/Dockerfile.dev
@@ -1,0 +1,59 @@
+FROM ruby:2.7.8
+ENV LANG C.UTF-8
+
+# 開発に便利なツールもインストール
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        curl \
+        ca-certificates \
+        libmariadb-dev-compat \
+        python \
+        make \
+        g++ \
+        vim \
+        git \
+        less \
+        mysql-client && \
+    rm -rf /var/lib/apt/lists/*
+
+# Node.js 14.x をNodeSourceリポジトリからインストール（node-sass 4.14.1との互換性確保）
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs && \
+    node --version && \
+    npm --version
+
+# Yarnをnpmでインストール
+RUN npm install -g yarn@1.22.19
+
+# Ruby 2.7で使用可能な最新のBundler 2.4.22をインストール
+RUN gem update --system 3.4.22 && gem install bundler -v 2.4.22
+
+# 開発用のツールをインストール
+RUN gem install \
+        solargraph \
+        rubocop \
+        rubocop-rails \
+        rubocop-rspec \
+        pry \
+        pry-rails \
+        pry-byebug
+
+ENV APP_ROOT /daily-report
+RUN mkdir -p $APP_ROOT
+WORKDIR $APP_ROOT
+
+# エントリーポイントスクリプトを作成
+RUN echo '#!/bin/bash\n\
+set -e\n\
+\n\
+# Remove a potentially pre-existing server.pid for Rails.\n\
+rm -f /daily-report/tmp/pids/server.pid\n\
+\n\
+# Then exec the container's main process (what'\''s set as CMD in the dockerfile).\n\
+exec "$@"' > /usr/bin/entrypoint.sh && \
+    chmod +x /usr/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]
+
+EXPOSE 3000 3035

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -1,0 +1,215 @@
+# 開発環境セットアップガイド
+
+このドキュメントでは、Daily Reportアプリケーションの開発環境をDocker Composeを使って構築する手順を説明します。
+
+## 前提条件
+
+- Docker Desktop for Mac/Windows または Docker Engine (Linux)
+- Docker Compose v1.27.0以上
+- Git
+
+## クイックスタート
+
+```bash
+# リポジトリをクローン
+git clone https://github.com/xtone/daily-report.git
+cd daily-report
+
+# 開発環境をセットアップ
+./scripts/setup-dev.sh
+```
+
+## 手動セットアップ
+
+### 1. 環境変数の設定
+
+```bash
+cp .env.example .env
+```
+
+必要に応じて`.env`ファイルを編集してください。
+
+### 2. Dockerイメージのビルド
+
+```bash
+docker-compose -f docker-compose.dev.yml build
+```
+
+### 3. データベースの起動
+
+```bash
+docker-compose -f docker-compose.dev.yml up -d db
+```
+
+### 4. データベースのセットアップ
+
+```bash
+docker-compose -f docker-compose.dev.yml run --rm app bundle exec rails db:create db:migrate
+```
+
+### 5. 初期データの投入（オプション）
+
+```bash
+docker-compose -f docker-compose.dev.yml run --rm app bundle exec rails app:import_csv
+```
+
+### 6. アプリケーションの起動
+
+```bash
+docker-compose -f docker-compose.dev.yml up
+```
+
+## アクセス情報
+
+- **アプリケーション**: http://localhost:3000
+- **Webpack Dev Server**: http://localhost:3035
+- **MySQL**: localhost:3307
+  - ユーザー名: root
+  - パスワード: password
+  - データベース名: daily_report_development
+
+## 開発時の便利なコマンド
+
+### ログの確認
+
+```bash
+# すべてのログを確認
+docker-compose -f docker-compose.dev.yml logs -f
+
+# 特定のサービスのログを確認
+docker-compose -f docker-compose.dev.yml logs -f app
+```
+
+### Rails console
+
+```bash
+docker-compose -f docker-compose.dev.yml exec app bundle exec rails console
+```
+
+### データベースコンソール
+
+```bash
+docker-compose -f docker-compose.dev.yml exec db mysql -u root -ppassword daily_report_development
+```
+
+### テストの実行
+
+```bash
+# すべてのテストを実行
+docker-compose -f docker-compose.dev.yml exec app bundle exec rspec
+
+# 特定のテストを実行
+docker-compose -f docker-compose.dev.yml exec app bundle exec rspec spec/models/user_spec.rb
+```
+
+### マイグレーション
+
+```bash
+# マイグレーションの実行
+docker-compose -f docker-compose.dev.yml exec app bundle exec rails db:migrate
+
+# マイグレーションのロールバック
+docker-compose -f docker-compose.dev.yml exec app bundle exec rails db:rollback
+```
+
+### Gemの追加
+
+```bash
+# Gemfileを編集後
+docker-compose -f docker-compose.dev.yml exec app bundle install
+```
+
+### npm/Yarnパッケージの追加
+
+```bash
+# package.jsonを編集後
+docker-compose -f docker-compose.dev.yml exec app yarn install
+```
+
+### コンテナの操作
+
+```bash
+# コンテナの起動
+docker-compose -f docker-compose.dev.yml up -d
+
+# コンテナの停止
+docker-compose -f docker-compose.dev.yml down
+
+# コンテナの再起動
+docker-compose -f docker-compose.dev.yml restart
+
+# コンテナとボリュームの削除（データも削除されます）
+docker-compose -f docker-compose.dev.yml down -v
+```
+
+## トラブルシューティング
+
+### ポートが使用中の場合
+
+`docker-compose.dev.yml`でポート番号を変更できます：
+
+```yaml
+services:
+  app:
+    ports:
+      - "3001:3000"  # 3000の代わりに3001を使用
+```
+
+### 権限エラーが発生する場合
+
+ボリュームの権限問題が発生した場合は、以下のコマンドで修正できます：
+
+```bash
+docker-compose -f docker-compose.dev.yml exec app chown -R $(id -u):$(id -g) .
+```
+
+### データベース接続エラー
+
+データベースが完全に起動するまで時間がかかることがあります。以下のコマンドで確認できます：
+
+```bash
+docker-compose -f docker-compose.dev.yml exec db mysqladmin ping -h localhost -u root -ppassword
+```
+
+### Webpackerのコンパイルエラー
+
+node_modulesを再インストールしてみてください：
+
+```bash
+docker-compose -f docker-compose.dev.yml exec app rm -rf node_modules
+docker-compose -f docker-compose.dev.yml exec app yarn install
+```
+
+## VSCode/RubyMine設定
+
+### VSCode
+
+`.vscode/settings.json`に以下を追加：
+
+```json
+{
+  "ruby.pathToBundler": "docker-compose -f docker-compose.dev.yml exec -T app bundle",
+  "ruby.useBundler": true,
+  "solargraph.useBundler": true,
+  "solargraph.commandPath": "docker-compose -f docker-compose.dev.yml exec -T app solargraph"
+}
+```
+
+### RubyMine
+
+1. Settings > Build, Execution, Deployment > Docker
+2. Docker Composeファイルとして`docker-compose.dev.yml`を指定
+3. Ruby SDK設定でDockerコンテナ内のRubyを指定
+
+## 開発フロー
+
+1. featureブランチを作成
+2. 開発環境で変更を実施
+3. テストを実行して確認
+4. コミット・プッシュ
+5. プルリクエストを作成
+
+## 参考リンク
+
+- [Docker Compose公式ドキュメント](https://docs.docker.com/compose/)
+- [Rails Docker化ベストプラクティス](https://docs.docker.com/samples/rails/)

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+echo "=== Daily Report 開発環境セットアップ ==="
+echo ""
+
+# .envファイルの作成
+if [ ! -f .env ]; then
+    echo "📝 .envファイルを作成しています..."
+    cp .env.example .env
+    echo "✅ .envファイルを作成しました"
+else
+    echo "ℹ️  .envファイルは既に存在します"
+fi
+
+# docker-compose.override.ymlの作成
+if [ ! -f docker-compose.override.yml ]; then
+    echo "📝 docker-compose.override.ymlを作成しています..."
+    cp docker-compose.override.yml.example docker-compose.override.yml 2>/dev/null || true
+    echo "✅ docker-compose.override.ymlを作成しました"
+fi
+
+# Dockerイメージのビルド
+echo ""
+echo "🏗️  Dockerイメージをビルドしています..."
+docker-compose -f docker-compose.dev.yml build
+
+# コンテナの起動
+echo ""
+echo "🚀 コンテナを起動しています..."
+docker-compose -f docker-compose.dev.yml up -d db
+
+# データベースの起動を待つ
+echo ""
+echo "⏳ データベースの起動を待っています..."
+sleep 10
+
+# データベースのセットアップ
+echo ""
+echo "💾 データベースをセットアップしています..."
+docker-compose -f docker-compose.dev.yml run --rm app bundle exec rails db:create db:migrate
+
+# 初期データの投入
+echo ""
+read -p "初期データを投入しますか？ (y/N): " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "📊 初期データを投入しています..."
+    docker-compose -f docker-compose.dev.yml run --rm app bundle exec rails app:import_csv
+fi
+
+# アプリケーションの起動
+echo ""
+echo "🎯 アプリケーションを起動しています..."
+docker-compose -f docker-compose.dev.yml up -d
+
+echo ""
+echo "✨ セットアップが完了しました！"
+echo ""
+echo "📋 アクセス情報:"
+echo "  - アプリケーション: http://localhost:3000"
+echo "  - Webpack Dev Server: http://localhost:3035"
+echo "  - MySQL: localhost:3307 (user: root, password: password)"
+echo ""
+echo "🔧 便利なコマンド:"
+echo "  - ログ確認: docker-compose -f docker-compose.dev.yml logs -f"
+echo "  - Rails console: docker-compose -f docker-compose.dev.yml exec app bundle exec rails console"
+echo "  - テスト実行: docker-compose -f docker-compose.dev.yml exec app bundle exec rspec"
+echo "  - 停止: docker-compose -f docker-compose.dev.yml down"
+echo ""


### PR DESCRIPTION
## 概要
ローカル開発環境を簡単に構築できるDocker Compose設定を追加しました。

Closes #169

## 変更内容

### 新規ファイル
- `docker-compose.dev.yml` - 開発環境専用のDocker Compose設定
- `docker/rails/Dockerfile.dev` - 開発ツール入りのDockerfile
- `scripts/setup-dev.sh` - ワンコマンドセットアップスクリプト
- `.env.example` - 環境変数のテンプレート
- `docker-compose.test.yml` - テスト実行用設定
- `Makefile` - よく使うコマンドのショートカット
- `docs/development-setup.md` - 詳細なセットアップガイド

### 更新ファイル
- `README.md` - クイックスタートセクションを追加
- `.gitignore` - .envファイルを追加

## 主な機能

### 開発環境の特徴
- ✅ ホットリロード対応（Webpackerの変更を即座に反映）
- ✅ デバッグツール完備（pry、byebug、solargraph）
- ✅ ポート競合回避（MySQL: 3307、Rails: 3000）
- ✅ node_modulesの永続化（再インストール不要）
- ✅ ヘルスチェック付き

### セットアップの簡易化
```bash
# これだけで環境構築完了！
./scripts/setup-dev.sh
```

### Makefileによる操作簡略化
```bash
make up      # コンテナ起動
make console # Rails console
make test    # テスト実行
make logs    # ログ確認
```

## 動作確認

- [ ] `./scripts/setup-dev.sh`でセットアップが完了すること
- [ ] http://localhost:3000 でアプリケーションにアクセスできること
- [ ] `make console`でRails consoleが起動すること
- [ ] `make test`でテストが実行されること
- [ ] ファイル変更時にホットリロードが効くこと

## 今後の改善点
- GitHub Codespacesとの統合
- VSCode Dev Container設定の追加
- CI/CD環境との統一化

🤖 Generated with [Claude Code](https://claude.ai/code)