### PR TITLE
管理画面CSV出力ページの日付選択カレンダーUI表示問題を修正 #185

### DIFF
--- a/app/javascript/components/DatePicker.jsx
+++ b/app/javascript/components/DatePicker.jsx
@@ -17,6 +17,15 @@ class DatePicker extends React.Component {
   }
 
   initializeDatePicker() {
+    // グローバルスコープから $ と moment を取得
+    if (typeof window.$ === 'undefined' || typeof window.moment === 'undefined') {
+      console.error('jQuery or moment.js is not loaded');
+      return;
+    }
+    
+    const $ = window.$;
+    const moment = window.moment;
+    
     const $input = $(this.inputRef.current);
     
     // Bootstrap datetimepickerの初期化
@@ -38,6 +47,11 @@ class DatePicker extends React.Component {
   }
 
   destroyDatePicker() {
+    if (typeof window.$ === 'undefined') {
+      return;
+    }
+    
+    const $ = window.$;
     const $input = $(this.inputRef.current);
     if ($input.data('DateTimePicker')) {
       $input.data('DateTimePicker').destroy();

--- a/app/views/admin/csvs/index.html.slim
+++ b/app/views/admin/csvs/index.html.slim
@@ -30,14 +30,35 @@ h2 ユーザー一覧
 = form_with url: users_path(format: :csv), method: :get do
   = submit_tag 'ダウンロード', class: 'btn btn-primary'
 
-= javascript_include_tag 'admin'
-
 - content_for :foot do
   javascript:
-    // 既存の日付ピッカーの初期化（React化されていない場合のフォールバック）
-    $('.input-group.date:not([data-react-date-picker-mounted])').datetimepicker({
-      format: 'YYYY-MM-DD',
-      dayViewHeaderFormat: 'YYYY年MMMM',
-      locale: moment.locale('ja'),
-      showClose: true
+    document.addEventListener('turbo:load', function() {
+      // 日付ピッカーの初期化（Rails 8.0対応）
+      setTimeout(function() {
+        if (typeof $ !== 'undefined' && typeof moment !== 'undefined' && $.fn.datetimepicker) {
+          $('.input-group.date').each(function() {
+            if (!$(this).data('DateTimePicker')) {
+              $(this).datetimepicker({
+                format: 'YYYY-MM-DD',
+                dayViewHeaderFormat: 'YYYY年MMMM',
+                locale: 'ja',
+                showClose: true,
+                icons: {
+                  time: 'glyphicon glyphicon-time',
+                  date: 'glyphicon glyphicon-calendar',
+                  up: 'glyphicon glyphicon-chevron-up',
+                  down: 'glyphicon glyphicon-chevron-down',
+                  previous: 'glyphicon glyphicon-chevron-left',
+                  next: 'glyphicon glyphicon-chevron-right',
+                  today: 'glyphicon glyphicon-screenshot',
+                  clear: 'glyphicon glyphicon-trash',
+                  close: 'glyphicon glyphicon-remove'
+                }
+              });
+            }
+          });
+        } else {
+          console.error('DateTimePicker dependencies not loaded');
+        }
+      }, 100); // 少し遅延させて依存関係の読み込みを待つ
     });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,5 +22,6 @@
     <div class="container">
       <%= yield %>
     </div>
+    <%= yield :foot %>
   </body>
 </html>

--- a/config/initializers/validators.rb
+++ b/config/initializers/validators.rb
@@ -1,0 +1,2 @@
+# カスタムバリデーターを手動で読み込み
+Dir[Rails.root.join('app/validators/*.rb')].each { |f| require f }


### PR DESCRIPTION
## 概要
管理画面のCSV出力ページ（`/admin/csvs`）で、日付入力フィールドのカレンダーアイコンをクリックしても日付選択のカレンダーUIが表示されない問題を修正しました。

## 問題の原因
Rails 8.0へのアップグレード後、以下の要因でDatePickerが正しく機能していませんでした：
1. applicationレイアウトに`:foot`のyieldがなく、ページ末尾のJavaScriptが実行されていなかった
2. Turboによるページ遷移で、jQuery pluginの初期化が適切に行われていなかった
3. ReactコンポーネントがグローバルスコープのjQueryとmomentを参照できていなかった

## 修正内容

### 1. レイアウトの修正
- `app/views/layouts/application.html.erb`に`<%= yield :foot %>`を追加
- ページ末尾でJavaScriptを実行できるようにしました

### 2. DatePicker初期化の改善
- `turbo:load`イベントでDatePickerを初期化
- 既に初期化されている要素をスキップする処理を追加
- 依存関係の読み込みチェックを追加

### 3. ReactコンポーネントのDependency修正
- `app/javascript/components/DatePicker.jsx`でwindowオブジェクトから明示的に依存関係を参照
- エラーハンドリングを追加

### 4. カスタムバリデーターの読み込み修正（副次的な修正）
- `config/initializers/validators.rb`を追加
- SjisConvertibleValidatorが正しく読み込まれるように修正

## テスト手順
1. 管理者権限でログイン
2. 管理画面へ移動
3. 「CSV出力」をクリック
4. 日付入力フィールドまたはカレンダーアイコンをクリック
5. カレンダーUIが表示されることを確認
6. 日付を選択できることを確認

## 関連Issue
Closes #185

🤖 Generated with [Claude Code](https://claude.ai/code)