### PR TITLE
修正: 稼働集計と日報未提出一覧の日付選択カレンダーおよびCSVダウンロード機能

### DIFF
--- a/app/assets/javascripts/summary_datepicker.js
+++ b/app/assets/javascripts/summary_datepicker.js
@@ -1,0 +1,85 @@
+//= require jquery
+//= require moment
+//= require moment/ja.js
+//= require bootstrap-datetimepicker
+
+$(document).on('turbo:load', function() {
+  // 日付ピッカーの初期化（Rails 8.0対応）
+  initializeSummaryDatePickers();
+});
+
+$(document).ready(function() {
+  // Turboを使わない場合のフォールバック
+  if (!window.Turbo) {
+    initializeSummaryDatePickers();
+  }
+});
+
+function initializeSummaryDatePickers() {
+  console.log('Initializing summary date pickers...');
+  console.log('jQuery available:', typeof $ !== 'undefined');
+  console.log('moment available:', typeof moment !== 'undefined');
+  console.log('datetimepicker available:', typeof $.fn !== 'undefined' && typeof $.fn.datetimepicker !== 'undefined');
+  
+  if (typeof $ === 'undefined' || typeof moment === 'undefined') {
+    console.error('Required dependencies not loaded');
+    return;
+  }
+  
+  if (typeof $.fn.datetimepicker === 'undefined') {
+    console.error('DateTimePicker plugin not loaded');
+    return;
+  }
+  
+  // サマリーページ特有の日付ピッカー初期化
+  $('#summaryRender .input-group.date').each(function() {
+    var $this = $(this);
+    if (!$this.data('DateTimePicker')) {
+      console.log('Initializing summary datepicker on element:', this);
+      $this.datetimepicker({
+        format: 'YYYY-MM-DD',
+        dayViewHeaderFormat: 'YYYY年MMMM',
+        locale: 'ja',
+        showClose: true,
+        icons: {
+          time: 'glyphicon glyphicon-time',
+          date: 'glyphicon glyphicon-calendar',
+          up: 'glyphicon glyphicon-chevron-up',
+          down: 'glyphicon glyphicon-chevron-down',
+          previous: 'glyphicon glyphicon-chevron-left',
+          next: 'glyphicon glyphicon-chevron-right',
+          today: 'glyphicon glyphicon-screenshot',
+          clear: 'glyphicon glyphicon-trash',
+          close: 'glyphicon glyphicon-remove'
+        }
+      });
+      console.log('Summary DatePicker initialized successfully');
+      
+      // 日付が変更されたときにCSVダウンロードボタンを有効化
+      $this.on('dp.change', function(e) {
+        console.log('Date changed:', e.date);
+        enableSummaryDownloadButton();
+        
+        // CSVダウンロードフォームの隠しフィールドを更新
+        var fieldName = $(this).find('input').attr('name');
+        var newDate = $(this).find('input').val();
+        if (fieldName === 'reports[start]') {
+          $('#csv_start_date').val(newDate);
+        } else if (fieldName === 'reports[end]') {
+          $('#csv_end_date').val(newDate);
+        }
+      });
+    }
+  });
+}
+
+// CSVダウンロードボタンを有効化する関数
+function enableSummaryDownloadButton() {
+  var downloadForm = document.getElementById('summaryDownload');
+  if (downloadForm) {
+    var submitButton = downloadForm.querySelector('input[type="submit"]');
+    if (submitButton) {
+      submitButton.removeAttribute('disabled');
+    }
+  }
+}

--- a/app/assets/javascripts/unsubmitted_datepicker.js
+++ b/app/assets/javascripts/unsubmitted_datepicker.js
@@ -1,0 +1,57 @@
+//= require jquery
+//= require moment
+//= require moment/ja.js
+//= require bootstrap-datetimepicker
+
+$(document).on('turbo:load', function() {
+  initializeUnsubmittedDatePickers();
+});
+
+$(document).ready(function() {
+  if (!window.Turbo) {
+    initializeUnsubmittedDatePickers();
+  }
+});
+
+function initializeUnsubmittedDatePickers() {
+  console.log('Initializing unsubmitted date pickers...');
+  console.log('jQuery available:', typeof $ !== 'undefined');
+  console.log('moment available:', typeof moment !== 'undefined');
+  console.log('datetimepicker available:', typeof $.fn !== 'undefined' && typeof $.fn.datetimepicker !== 'undefined');
+  
+  if (typeof $ === 'undefined' || typeof moment === 'undefined') {
+    console.error('Required dependencies not loaded');
+    return;
+  }
+  
+  if (typeof $.fn.datetimepicker === 'undefined') {
+    console.error('DateTimePicker plugin not loaded');
+    return;
+  }
+  
+  // 日報未提出一覧ページの日付ピッカーを初期化
+  $('#unsubmittedsRender .input-group.date').each(function() {
+    var $this = $(this);
+    if (!$this.data('DateTimePicker')) {
+      console.log('Initializing datepicker on element:', this);
+      $this.datetimepicker({
+        format: 'YYYY-MM-DD',
+        dayViewHeaderFormat: 'YYYY年MMMM',
+        locale: 'ja',
+        showClose: true,
+        icons: {
+          time: 'glyphicon glyphicon-time',
+          date: 'glyphicon glyphicon-calendar',
+          up: 'glyphicon glyphicon-chevron-up',
+          down: 'glyphicon glyphicon-chevron-down',
+          previous: 'glyphicon glyphicon-chevron-left',
+          next: 'glyphicon glyphicon-chevron-right',
+          today: 'glyphicon glyphicon-screenshot',
+          clear: 'glyphicon glyphicon-trash',
+          close: 'glyphicon glyphicon-remove'
+        }
+      });
+      console.log('DatePicker initialized successfully');
+    }
+  });
+}

--- a/app/controllers/reports/summaries_controller.rb
+++ b/app/controllers/reports/summaries_controller.rb
@@ -7,7 +7,7 @@ class Reports::SummariesController < ApplicationController
     authorize Report.new, :summary?
     respond_to do |format|
       format.csv do
-        raise ActiveRecord::RecordNotFoundunless unless params[:reports].present?
+        raise ActiveRecord::RecordNotFound unless params[:reports].present?
 
         @start_date = Date.parse(params[:reports][:start])
         @end_date = Date.parse(params[:reports][:end])

--- a/app/views/reports/summaries/show.html.slim
+++ b/app/views/reports/summaries/show.html.slim
@@ -23,6 +23,8 @@ h1 稼働集計
     | または
   .p-2
     = form_with url: summary_path(format: :csv), method: :get, id: 'summaryDownload' do
+      input type="hidden" name="reports[start]" id="csv_start_date" value="#{@start_date.strftime('%Y-%m-%d')}"
+      input type="hidden" name="reports[end]" id="csv_end_date" value="#{@end_date.strftime('%Y-%m-%d')}"
       = submit_tag 'CSVダウンロード', class: 'btn btn-primary'
 
 - if params[:reports].present?
@@ -49,11 +51,5 @@ h1 稼働集計
 
 = javascript_include_tag 'reports_summary'
 
-- content_for :foot do
-  javascript:
-    $('.input-group.date').datetimepicker({
-      format: 'YYYY-MM-DD',
-      dayViewHeaderFormat: 'YYYY年MMMM',
-      locale: moment.locale('ja'),
-      showClose: true
-    });
+- content_for :head do
+  = javascript_include_tag 'summary_datepicker'

--- a/app/views/reports/unsubmitteds/show.html.slim
+++ b/app/views/reports/unsubmitteds/show.html.slim
@@ -4,7 +4,7 @@ h1 日報未提出一覧
 
 = render_flash_message
 
-= form_with url: unsubmitted_path, method: :get, class: 'form-inline' do
+= form_with url: unsubmitted_path, method: :get, class: 'form-inline', id: 'unsubmittedsRender' do
   .form-group
     .input-group.date
       input.form-control.date-input type="text" name="reports[start]" placeholder="集計開始日" value="#{@start_date.strftime('%Y-%m-%d')}"
@@ -31,12 +31,5 @@ h1 日報未提出一覧
 
 = javascript_include_tag 'unsubmitted'
 
-- content_for :foot do
-  javascript:
-    // 既存の日付ピッカーの初期化（React化されていない場合のフォールバック）
-    $('.input-group.date:not([data-react-mounted])').datetimepicker({
-      format: 'YYYY-MM-DD',
-      dayViewHeaderFormat: 'YYYY年MMMM',
-      locale: moment.locale('ja'),
-      showClose: true
-    });
+- content_for :head do
+  = javascript_include_tag 'unsubmitted_datepicker'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,4 +7,4 @@ Rails.application.config.assets.version = "1.0"
 # Rails.application.config.assets.paths << Emoji.images_path
 
 # Precompile additional assets.
-Rails.application.config.assets.precompile += %w( csv_datepicker.js )
+Rails.application.config.assets.precompile += %w( csv_datepicker.js summary_datepicker.js unsubmitted_datepicker.js )


### PR DESCRIPTION
## 概要
Issue #188, #189, #190 の3つの不具合を修正します。

## 修正内容

### 1. 稼働集計画面のカレンダーUI修正 (Issue #188)
- 専用の`summary_datepicker.js`を作成
- Turbo Drive対応の初期化処理を実装
- ビューファイルのインラインJavaScriptを外部ファイルに移行

### 2. 稼働集計画面のCSVダウンロード修正 (Issue #189)
- コントローラーの構文エラー修正（`RecordNotFoundunless` → `RecordNotFound`）
- CSVダウンロードフォームに日付パラメータを追加（隠しフィールド）
- 日付選択時に隠しフィールドを自動更新する機能を追加

### 3. 日報未提出一覧画面のカレンダーUI修正 (Issue #190)
- 専用の`unsubmitted_datepicker.js`を作成
- フォームにID属性を追加して適切にターゲティング
- インラインJavaScriptを外部ファイルに移行

## テスト内容
- [ ] 稼働集計画面でカレンダーアイコンをクリックするとカレンダーが表示される
- [ ] 稼働集計画面で日付を選択後、CSVダウンロードボタンで正しいデータがダウンロードされる
- [ ] 日報未提出一覧画面でカレンダーアイコンをクリックするとカレンダーが表示される
- [ ] 管理画面のCSV出力ページ（/admin/csvs）の動作に影響がないことを確認

## 関連Issue
- Fixes #188
- Fixes #189
- Fixes #190

🤖 Generated with [Claude Code](https://claude.ai/code)