### PR TITLE
fix: Rails 8.0環境でのCSVページ日付ピッカー問題を修正

### DIFF
--- a/app/assets/javascripts/csv_datepicker.js
+++ b/app/assets/javascripts/csv_datepicker.js
@@ -3,38 +3,36 @@
 //= require moment/ja.js
 //= require bootstrap-datetimepicker
 
-$(document).on('turbo:load', function() {
-  // 日付ピッカーの初期化（Rails 8.0対応）
-  initializeDatePickers();
-});
+// Rails 8.0でTurboと連携するための日付ピッカー初期化
+(function() {
+  'use strict';
 
-$(document).ready(function() {
-  // Turboを使わない場合のフォールバック
-  if (!window.Turbo) {
+  // Turboイベントの登録
+  document.addEventListener('turbo:load', function() {
     initializeDatePickers();
-  }
-});
+  });
+
+  // DOMContentLoadedイベントでも初期化（初回ページロード時）
+  document.addEventListener('DOMContentLoaded', function() {
+    initializeDatePickers();
+  });
+
+  // turbo:renderイベントでも初期化（Turboフレーム更新時）
+  document.addEventListener('turbo:render', function() {
+    initializeDatePickers();
+  });
+})();
 
 function initializeDatePickers() {
-  console.log('Initializing date pickers...');
-  console.log('jQuery available:', typeof $ !== 'undefined');
-  console.log('moment available:', typeof moment !== 'undefined');
-  console.log('datetimepicker available:', typeof $.fn !== 'undefined' && typeof $.fn.datetimepicker !== 'undefined');
-  
-  if (typeof $ === 'undefined' || typeof moment === 'undefined') {
-    console.error('Required dependencies not loaded');
+  // 依存関係のチェック
+  if (typeof $ === 'undefined' || typeof moment === 'undefined' || typeof $.fn.datetimepicker === 'undefined') {
     return;
   }
   
-  if (typeof $.fn.datetimepicker === 'undefined') {
-    console.error('DateTimePicker plugin not loaded');
-    return;
-  }
-  
+  // 日付ピッカーの初期化
   $('.input-group.date').each(function() {
     var $this = $(this);
     if (!$this.data('DateTimePicker')) {
-      console.log('Initializing datepicker on element:', this);
       $this.datetimepicker({
         format: 'YYYY-MM-DD',
         dayViewHeaderFormat: 'YYYY年MMMM',
@@ -52,7 +50,6 @@ function initializeDatePickers() {
           close: 'glyphicon glyphicon-remove'
         }
       });
-      console.log('DatePicker initialized successfully');
     }
   });
 }

--- a/app/assets/javascripts/summary_datepicker.js
+++ b/app/assets/javascripts/summary_datepicker.js
@@ -3,31 +3,29 @@
 //= require moment/ja.js
 //= require bootstrap-datetimepicker
 
-$(document).on('turbo:load', function() {
-  // 日付ピッカーの初期化（Rails 8.0対応）
-  initializeSummaryDatePickers();
-});
+// Rails 8.0でTurboと連携するための日付ピッカー初期化
+(function() {
+  'use strict';
 
-$(document).ready(function() {
-  // Turboを使わない場合のフォールバック
-  if (!window.Turbo) {
+  // Turboイベントの登録
+  document.addEventListener('turbo:load', function() {
     initializeSummaryDatePickers();
-  }
-});
+  });
+
+  // DOMContentLoadedイベントでも初期化（初回ページロード時）
+  document.addEventListener('DOMContentLoaded', function() {
+    initializeSummaryDatePickers();
+  });
+
+  // turbo:renderイベントでも初期化（Turboフレーム更新時）
+  document.addEventListener('turbo:render', function() {
+    initializeSummaryDatePickers();
+  });
+})();
 
 function initializeSummaryDatePickers() {
-  console.log('Initializing summary date pickers...');
-  console.log('jQuery available:', typeof $ !== 'undefined');
-  console.log('moment available:', typeof moment !== 'undefined');
-  console.log('datetimepicker available:', typeof $.fn !== 'undefined' && typeof $.fn.datetimepicker !== 'undefined');
-  
-  if (typeof $ === 'undefined' || typeof moment === 'undefined') {
-    console.error('Required dependencies not loaded');
-    return;
-  }
-  
-  if (typeof $.fn.datetimepicker === 'undefined') {
-    console.error('DateTimePicker plugin not loaded');
+  // 依存関係のチェック
+  if (typeof $ === 'undefined' || typeof moment === 'undefined' || typeof $.fn.datetimepicker === 'undefined') {
     return;
   }
   

--- a/app/assets/javascripts/unsubmitted_datepicker.js
+++ b/app/assets/javascripts/unsubmitted_datepicker.js
@@ -3,29 +3,29 @@
 //= require moment/ja.js
 //= require bootstrap-datetimepicker
 
-$(document).on('turbo:load', function() {
-  initializeUnsubmittedDatePickers();
-});
+// Rails 8.0でTurboと連携するための日付ピッカー初期化
+(function() {
+  'use strict';
 
-$(document).ready(function() {
-  if (!window.Turbo) {
+  // Turboイベントの登録
+  document.addEventListener('turbo:load', function() {
     initializeUnsubmittedDatePickers();
-  }
-});
+  });
+
+  // DOMContentLoadedイベントでも初期化（初回ページロード時）
+  document.addEventListener('DOMContentLoaded', function() {
+    initializeUnsubmittedDatePickers();
+  });
+
+  // turbo:renderイベントでも初期化（Turboフレーム更新時）
+  document.addEventListener('turbo:render', function() {
+    initializeUnsubmittedDatePickers();
+  });
+})();
 
 function initializeUnsubmittedDatePickers() {
-  console.log('Initializing unsubmitted date pickers...');
-  console.log('jQuery available:', typeof $ !== 'undefined');
-  console.log('moment available:', typeof moment !== 'undefined');
-  console.log('datetimepicker available:', typeof $.fn !== 'undefined' && typeof $.fn.datetimepicker !== 'undefined');
-  
-  if (typeof $ === 'undefined' || typeof moment === 'undefined') {
-    console.error('Required dependencies not loaded');
-    return;
-  }
-  
-  if (typeof $.fn.datetimepicker === 'undefined') {
-    console.error('DateTimePicker plugin not loaded');
+  // 依存関係のチェック
+  if (typeof $ === 'undefined' || typeof moment === 'undefined' || typeof $.fn.datetimepicker === 'undefined') {
     return;
   }
   


### PR DESCRIPTION
## 概要
Rails 8.0環境で/admin/csvページの日付ピッカーが動作しない問題を修正しました。

## 問題
- カレンダーアイコンをクリックしても日付選択UIが表示されない
- Turboによるページ遷移時にJavaScriptの初期化が適切に行われていなかった

## 修正内容
1. **Turboイベントハンドリングの改善**
   - `turbo:load`イベントに加えて`DOMContentLoaded`と`turbo:render`イベントでも初期化
   - より確実な初期化処理を実装

2. **統一された実装の適用**
   - csv_datepicker.js
   - summary_datepicker.js
   - unsubmitted_datepicker.js
   の3ファイルで同じ初期化パターンを使用

3. **コードのクリーンアップ**
   - デバッグ用のconsole.logを削除
   - 依存関係チェックを簡潔に

## 動作確認
- [x] /admin/csvページで日付ピッカーが正常に動作することを確認
- [x] ページ遷移後も日付ピッカーが動作することを確認
- [x] JavaScriptエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)